### PR TITLE
Allow creating parser from match expression

### DIFF
--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -156,6 +156,12 @@ let expand_function ~loc cases =
   let match_expr = Ast_builder.Default.pexp_match ~loc to_match_expr cases in
   [%expr function ppx____parser____stream____ -> [%e match_expr]]
 
-let expand_function_from_ctxt ~ctxt cases =
+let expand_parser ~loc = function
+  | (Some e), cases ->
+    Ast_builder.Default.pexp_apply ~loc (expand_function ~loc cases) [(Nolabel, e)]
+  | None, cases ->
+    expand_function ~loc cases
+
+let expand_parser_from_ctxt ~ctxt =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
-  expand_function ~loc cases
+  expand_parser ~loc

--- a/rewriter/ppx_parser.ml
+++ b/rewriter/ppx_parser.ml
@@ -1,10 +1,14 @@
 open Ppxlib
 
-let ppx_parser_pat = Ast_pattern.(single_expr_payload (pexp_function __))
+let ppx_parser_pat = Ast_pattern.(single_expr_payload
+  (alt
+    (pexp_function __ |> map1 ~f:(fun cases -> (None, cases)) )
+    (pexp_match __ __ |> map2 ~f:(fun e cases -> (Some e, cases)) ))
+  )
 
 let parser_extension =
   Extension.V3.declare "parser" Extension.Context.expression ppx_parser_pat
-    Ppx_parser_lib.Parser.expand_function_from_ctxt
+    Ppx_parser_lib.Parser.expand_parser_from_ctxt
 
 let parser_rule = Context_free.Rule.extension parser_extension
 let () = Driver.register_transformation ~rules:[ parser_rule ] "ppx_parser"

--- a/test/expansion/common/common.ml
+++ b/test/expansion/common/common.ml
@@ -25,4 +25,4 @@ let f e =
     ~on_error:(fun () ->
       Ppx_parser_lib.Err.err_expr_node ~loc:e.pexp_loc "Invalid test pattern.")
     e
-    (Ppx_parser_lib.Parser.expand_function ~loc)
+    (Ppx_parser_lib.Parser.expand_parser ~loc)

--- a/test/expansion/parser/parser_test.ml
+++ b/test/expansion/parser/parser_test.ml
@@ -8,6 +8,14 @@ let test_empty_parser () =
   in
   check_eq ~expected ~actual "empty"
 
+let test_empty_parser_match () =
+  let actual = f [%expr match %parser s with [] -> 1] in
+  let expected =
+    [%expr
+      (function ppx____parser____stream____ -> ( match [%e peek] with _ -> 1)) s]
+  in
+  check_eq ~expected ~actual "empty_match"
+
 let test_wildcard_parser () =
   let actual = f [%expr function%parser [ _ ] -> 1] in
   let expected =
@@ -94,6 +102,7 @@ let tests =
   let open Alcotest in
   [
     test_case "empty" `Quick test_empty_parser;
+    test_case "empty_match" `Quick test_empty_parser_match;
     test_case "pop_any" `Quick test_wildcard_parser;
     test_case "identity" `Quick test_identity_parser;
     test_case "seq" `Quick test_seq_parser;


### PR DESCRIPTION
In camlp4, it used to be possible to use this syntax:
```ocaml
match s with parser
| (** cases **)
```

This patch allows the following:
```ocaml
match%parser s with
|  (** cases **)
```

As seen from the test example, this simply creates a function that is immediately invoked with the match expression, i.e.
```ocaml
(function ppx____parser____stream____ -> (** cases **)) s
```