### PR TITLE
Allow binding stream to variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ and parse_expr = function%parser
     | [Int i; [%let op = parse_op i]] -> op
 ```
 
+#### Binding the stream
+
+For convenience, the stream itself can also be bound to a variable using the extension `%stream` (shorthand `%s`):
+
+```ocaml
+let parse = function%parser
+    | [1; 2; 3; [%stream s]] ->
+        continue_parse s;
+        "1, 2, 3, 4"
+```
+
+The `[%stream s]` expression must be the final element of the pattern.
+
 ### Guards
 Guards can be used as in *regular* pattern matching. A guard must evaluate to `true` for a match case to be selected:
 ```ocaml

--- a/lib/let.ml
+++ b/lib/let.ml
@@ -108,7 +108,7 @@ module Make (Args : LetArgs) = struct
 
   let expand_let_payload ~loc = function
     | PStr [ { pstr_desc = Pstr_eval (e, []); _ } ] -> expand_eval e
-    | _ -> (Err.err_expr_node ~loc "Invalid '%%let' payload", [%pat? _])
+    | _ -> (Err.err_expr_node ~loc "Invalid '%%let' payload.", [%pat? _])
 end
 
 module LetHd = Make (struct

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -46,7 +46,7 @@ let bind_stream_in ~loc var_pat e2 =
     [%e e2]]
 
 let error_stream_binding_end_of_pattern ~loc =
-  Err.err_expr_node ~loc "The '%%stream' binding can only be used at the end of the pattern"
+  Err.err_expr_node ~loc "The '%%stream' binding can only be used at the end of the pattern."
 
 let expand_stream_payload ~loc = function
   | PStr [ {
@@ -57,7 +57,7 @@ let expand_stream_payload ~loc = function
       }, []); _
     } ] ->
       Ast_builder.Default.ppat_var ~loc:ident_loc { txt = var; loc = var_loc }
-  | _ -> Err.err_pat_node ~loc "Invalid '%%stream' payload"
+  | _ -> Err.err_pat_node ~loc "Invalid '%%stream' payload."
 
 let rec expand_list_seq_tl ~loc result_expr = function
   | [%pat? []] -> result_expr

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -46,7 +46,7 @@ let bind_stream_in ~loc var_pat e2 =
     [%e e2]]
 
 let error_stream_binding_end_of_pattern ~loc =
-  Err.err_expr_node ~loc "'%%stream' binding must come at the end of the pattern"
+  Err.err_expr_node ~loc "The '%%stream' binding can only be used at the end of the pattern"
 
 let expand_stream_payload ~loc = function
   | PStr [ {

--- a/test/expansion/parser/parser_test.ml
+++ b/test/expansion/parser/parser_test.ml
@@ -70,9 +70,9 @@ let test_bind_stream_error_parser () =
           match [%e peek] with
           | Some 1 ->
             let () = [%e junk] in
-            [%ocaml.error "'%stream' binding must come at the end of the pattern"]
+            [%ocaml.error "The '%stream' binding can only be used at the end of the pattern"]
           | _ ->
-            [%ocaml.error "'%stream' binding must come at the end of the pattern"])]
+            [%ocaml.error "The '%stream' binding can only be used at the end of the pattern"])]
   in
   check_eq ~expected ~actual "bind_stream_error"
 

--- a/test/expansion/parser/parser_test.ml
+++ b/test/expansion/parser/parser_test.ml
@@ -70,9 +70,9 @@ let test_bind_stream_error_parser () =
           match [%e peek] with
           | Some 1 ->
             let () = [%e junk] in
-            [%ocaml.error "The '%stream' binding can only be used at the end of the pattern"]
+            [%ocaml.error "The '%stream' binding can only be used at the end of the pattern."]
           | _ ->
-            [%ocaml.error "The '%stream' binding can only be used at the end of the pattern"])]
+            [%ocaml.error "The '%stream' binding can only be used at the end of the pattern."])]
   in
   check_eq ~expected ~actual "bind_stream_error"
 

--- a/test/expansion/parser/parser_test.ml
+++ b/test/expansion/parser/parser_test.ml
@@ -44,6 +44,23 @@ let test_identity_parser () =
   in
   check_eq ~expected ~actual "identity"
 
+let test_bind_stream_parser () =
+  let actual = f [%expr function%parser [ 1; [%stream s] ] -> do_something s | [ [%s s] ] -> do_something s ] in
+  let expected =
+    [%expr
+      function
+      | ppx____parser____stream____ -> (
+          match [%e peek] with
+          | Some 1 ->
+            let () = [%e junk] in
+            let s = ppx____parser____stream____ in
+            do_something s
+          | _ ->
+            let s = ppx____parser____stream____ in
+            do_something s)]
+  in
+  check_eq ~expected ~actual "bind_stream"
+
 let test_seq_parser () =
   let actual =
     f [%expr function%parser [ 1; 2; 3 ] -> "1" | [ 4; 2 ] -> "2" | [] -> "0"]
@@ -103,6 +120,7 @@ let tests =
   [
     test_case "empty" `Quick test_empty_parser;
     test_case "empty_match" `Quick test_empty_parser_match;
+    test_case "bind_stream" `Quick test_bind_stream_parser;
     test_case "pop_any" `Quick test_wildcard_parser;
     test_case "identity" `Quick test_identity_parser;
     test_case "seq" `Quick test_seq_parser;

--- a/test/expansion/parser/parser_test.ml
+++ b/test/expansion/parser/parser_test.ml
@@ -61,6 +61,21 @@ let test_bind_stream_parser () =
   in
   check_eq ~expected ~actual "bind_stream"
 
+let test_bind_stream_error_parser () =
+  let actual = f [%expr function%parser [ 1; [%stream s]; 1 ] -> do_something s | [ [%s s]; 1 ] -> do_something s ] in
+  let expected =
+    [%expr
+      function
+      | ppx____parser____stream____ -> (
+          match [%e peek] with
+          | Some 1 ->
+            let () = [%e junk] in
+            [%ocaml.error "'%stream' binding must come at the end of the pattern"]
+          | _ ->
+            [%ocaml.error "'%stream' binding must come at the end of the pattern"])]
+  in
+  check_eq ~expected ~actual "bind_stream_error"
+
 let test_seq_parser () =
   let actual =
     f [%expr function%parser [ 1; 2; 3 ] -> "1" | [ 4; 2 ] -> "2" | [] -> "0"]
@@ -121,6 +136,7 @@ let tests =
     test_case "empty" `Quick test_empty_parser;
     test_case "empty_match" `Quick test_empty_parser_match;
     test_case "bind_stream" `Quick test_bind_stream_parser;
+    test_case "bind_stream_error" `Quick test_bind_stream_error_parser;
     test_case "pop_any" `Quick test_wildcard_parser;
     test_case "identity" `Quick test_identity_parser;
     test_case "seq" `Quick test_seq_parser;


### PR DESCRIPTION
In camlp4, it used to be possible to bind the stream to a variable:

```ocaml
let parse = parser
  | [< '"hello"; 'o; s >] ->
     (* o is bound to a token, but s is bound to the rest of the stream *)
```

This is useful as an idiom, for example is it used in many parts of the [haxe parser](https://github.com/HaxeFoundation/haxe/blob/2dc801f1e77bc5a464cc590536954bd305193b43/src/syntax/grammar.mly).

In `ppx_parser`, `s` would already bind to a token so a separate syntax is required for binding the stream. I have implemented it with the extension `%stream` or `%s`:

```ocaml
let parse = function%parser
  | [ "hello"; o; [%s s] ] ->
     (* o is bound to a token, but s is bound to the rest of the stream *)
```

Note that camlp4 used to impose no limitations on how variables could be bound like this, e.g.
```ocaml
let parse = parser
  | [< s1; '"hello"; s2; 'o; s3 >] -> 
     (* o is bound to a token, but s1, s2, s3 are bound to the rest of the stream *)
  | [< '"hello"; 'o; s1; s2; s3 >] -> 
     (* identical to the above case *)
```
However, I have opted to limit it to the final element in the pattern for simplicity.
