### PR TITLE
Relax constraint on OCaml version

### DIFF
--- a/ppx_parser.opam
+++ b/ppx_parser.opam
@@ -17,7 +17,7 @@ tags: ["stream parser"]
 homepage: "https://github.com/NielsMommen/ppx_parser"
 bug-reports: "https://github.com/NielsMommen/ppx_parser/issues"
 depends: [
-  "ocaml" {>= "4.13.0"}
+  "ocaml" {>= "4.13.0" with-test}
   "dune" {>= "2.9"}
   "ppxlib" {>= "0.27.0"}
   "alcotest" {with-test}


### PR DESCRIPTION
It looks like OCaml 4.13 is only needed to run the tests (for the List.equal function), the package itself installs and seems to work on older OCaml versions without errors. It is useful to still be able to build with OCaml 4.08 as it is packaged with Ubuntu 20.04 which is still supported at the moment.