### PR TITLE
Fix compatibility with ppxlib 0.36

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
    (>= 4.8.0))
   dune
   (ppxlib
-   (>= 0.27.0))
+   (>= 0.36.0))
   (alcotest
    (and
     :with-test

--- a/ppx_parser.opam
+++ b/ppx_parser.opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/NielsMommen/ppx_parser/issues"
 depends: [
   "ocaml" {>= "4.8.0"}
   "dune" {>= "2.9"}
-  "ppxlib" {>= "0.27.0"}
+  "ppxlib" {>= "0.36.0"}
   "alcotest" {with-test & >= "1.2.0"}
   "ppx_deriving" {with-test}
   "camlp-streams" {with-test}

--- a/rewriter/ppx_parser.ml
+++ b/rewriter/ppx_parser.ml
@@ -2,7 +2,7 @@ open Ppxlib
 
 let ppx_parser_pat = Ast_pattern.(single_expr_payload
   (alt
-    (pexp_function __ |> map1 ~f:(fun cases -> (None, cases)) )
+    (pexp_function drop drop (pfunction_cases __ drop drop) |> map1 ~f:(fun cases -> (None, cases)) )
     (pexp_match __ __ |> map2 ~f:(fun e cases -> (Some e, cases)) ))
   )
 


### PR DESCRIPTION
This applies the fix suggested at https://github.com/ocaml-ppx/ppxlib/issues/615#issuecomment-3612435489 for compatibility with ppxlib 0.36 and above.